### PR TITLE
Fix qnode_service_installer

### DIFF
--- a/qnode_service_installer
+++ b/qnode_service_installer
@@ -49,7 +49,7 @@ GOEXPERIMENT=arenas go build -o qclient main.go
 HOME=$(eval echo ~$HOME_DIR)
 # Use the home directory in the path
 NODE_PATH="$HOME/ceremonyclient/node"
-EXEC_START="$NODE_PATH/release_autorun.sh
+EXEC_START="$NODE_PATH/release_autorun.sh"
 
 # Create Ceremonyclient Service
 echo "⏳Creating Ceremonyclient Service"


### PR DESCRIPTION
Hey 👋 

This PR adds missing " on path export part of the latest script. I found it by trying to follow guide https://docs.quilibrium.one/quilibrium-node-setup-guide/node-auto-installer which broke for me with error:

> bash: line 89: unexpected EOF while looking for matching `"'